### PR TITLE
refactor/supplier-retailer-list-connection-swagger-response-schema

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -380,9 +380,6 @@ components:
       required:
         - Business
         - BusinessId
-        - DefaultPriceTier
-        - DefaultPriceTierId
-        - PriceTier
         - currency
       type: object
       properties:
@@ -392,15 +389,9 @@ components:
           type: number
         Business:
           $ref: "#/components/schemas/Business"
-        DefaultPriceTierId:
-          type: number
-        DefaultPriceTier:
-          $ref: "#/components/schemas/PriceTier"
         description:
           type: string
         imageUrl:
-          type: string
-        checkoutNotes:
           type: string
         showStock:
           type: boolean
@@ -412,10 +403,11 @@ components:
           type: string
         SupplierPaymentInformation:
           type: object
-        PriceTier:
-          $ref: "#/components/schemas/PriceTier"
-        currency:
-          type: object
+          properties:
+            bankAccountNumber:
+              type: string
+            bankSortCode:
+              type: string
     Retailer:
       type: object
       properties:
@@ -449,6 +441,8 @@ components:
     SupplierRetailerConnection:
       type: object
       properties:
+        id:
+          type: number
         SupplierId:
           type: number
         Supplier:
@@ -459,8 +453,6 @@ components:
           $ref: "#/components/schemas/Retailer"
         PriceTierId:
           type: number
-        PriceTier:
-          $ref: "#/components/schemas/PriceTier"
         initiator:
           type: string
         approved:
@@ -472,13 +464,9 @@ components:
           type: string
         notes:
           type: string
-        paymentType:
-          type: string
         paymentDue:
           type: number
           description: Days until payment due after an order is placed
-        deliveryCharge:
-          type: number
         fulfillmentType:
           type: string
         existingCustomer:
@@ -486,6 +474,7 @@ components:
         mailingListPermission:
           type: boolean
       required:
+        - id
         - SupplierId
         - Supplier
         - RetailerId
@@ -498,13 +487,10 @@ components:
         - customerCode
         - notes
         - Comments
-        - paymentType
         - paymentDue
-        - deliveryCharge
         - fulfillmentType
         - existingCustomer
         - mailingListPermission
-        - acceptLink
     PriceTierOrderRule:
       type: object
       properties: {}


### PR DESCRIPTION
**Description**

- Updates the supplier retailer list connection expected response swagger schema to correspond with the api-v2 endpoint `sellar-integrations/supplier-retailer-connections` on api-v2.
- Depends on https://github.com/sellar-io/sellar/pull/1424

Relates to: https://linear.app/sellar/issue/ENG-485/supplier-retailer-connection-v2-integration-redirect